### PR TITLE
add exclude rules

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,3 +17,4 @@ collections:
     output: true
 # Build settings
 markdown: kramdown
+exclude: ["package.json", "package-lock.json", "node_modules", ".sass-cache"]


### PR DESCRIPTION
Forestry is attempting to process these files as content, causing import errors